### PR TITLE
refactor: UI cleanup and code reuse

### DIFF
--- a/lua/hawtkeys/init.lua
+++ b/lua/hawtkeys/init.lua
@@ -1,5 +1,6 @@
 local M = {}
 function M.setup(config)
+    config = config or {}
     M.leader = config.leader or " "
     M.homerow = config.homerow or 2
     M.powerFingers = config.powerFingers or { 2, 3, 6, 7 }


### PR DESCRIPTION
Also gives the prompt a `> ` at the start, gives a custom border to the main results window so it looks like the prompt and results are just one window, and fixes a bug where you could open the UI on top of itself.

closes #14 