### PR TITLE
feat(score): boost combos using word initials for mnemonics

### DIFF
--- a/lua/hawtkeys/score.lua
+++ b/lua/hawtkeys/score.lua
@@ -4,26 +4,29 @@ local tsSearch = require("hawtkeys.ts")
 local utils = require("hawtkeys.utils")
 local already_used_keys = {}
 
+---@param str string
+---@return table<string, boolean>
+local function get_initials_set(str)
+    local initials = {}
+    for word in str:gmatch("%S+") do
+        initials[word:sub(1, 1):lower()] = true
+    end
+    return initials
+end
+
 ---@param key1 string
 ---@param key2 string
 ---@param str string
 ---@return integer
 local function mnemonic_score(key1, key2, str)
-    -- returns a bonus point if the keys are the first letter of a word
-    local words = {}
-    for word in str:gmatch("%S+") do
-        table.insert(words, word)
-    end
-
+    local initials = get_initials_set(str)
     local bonus = 0
-    for _, word in ipairs(words) do
-        if word:sub(1, 1):lower() == key1 or word:sub(1, 1):lower() == key2 then
-            bonus = bonus + 1
-        end
-    end
 
-    --if key1 equals first letter of string then bonus = bonus + 1
-    if str:sub(1, 1):lower() == key1 then
+    -- Bonus for matching word initials
+    if initials[key1] then
+        bonus = bonus + 1
+    end
+    if initials[key2] then
         bonus = bonus + 1
     end
 
@@ -91,16 +94,36 @@ end
 ---@param str string
 ---@return string[]
 local function generate_combos(str)
+    -- Get initials before removing leader
+    local initials_set = get_initials_set(str)
+    local initials = {}
+    for k, _ in pairs(initials_set) do
+        table.insert(initials, k)
+    end
+
+    -- Remove leader for positional combinations only
     str = str:gsub(hawtkeys.config.leader, "")
     local pairs = {}
     local len = #str
     for i = 1, len - 1 do
-        local char1 = str:sub(i, i):lower() -- Convert characters to lowercase
+        local char1 = str:sub(i, i):lower()
         for j = i + 1, len do
-            local char2 = str:sub(j, j):lower() -- Convert characters to lowercase
+            local char2 = str:sub(j, j):lower()
             table.insert(pairs, char1 .. char2)
         end
     end
+
+    -- Also generate combinations of word initials (e.g., "go" and "og" for "git open")
+    if #initials >= 2 then
+        for _, first in ipairs(initials) do
+            for _, second in ipairs(initials) do
+                if first ~= second then
+                    table.insert(pairs, first .. second)
+                end
+            end
+        end
+    end
+
     return pairs
 end
 

--- a/tests/hawtkeys/score_spec.lua
+++ b/tests/hawtkeys/score_spec.lua
@@ -1,0 +1,85 @@
+local hawtkeys = require("hawtkeys")
+---@diagnostic disable-next-line: undefined-field
+local eq = assert.are.same
+local score = require("hawtkeys.score")
+
+describe("mnemonic scoring", function()
+    before_each(function()
+        require("plenary.reload").reload_module("hawtkeys")
+        hawtkeys.setup({
+            keyboardLayout = "qwerty",
+        })
+    end)
+
+    it(
+        "should score word initial combinations highly for 'git open'",
+        function()
+            local results = score.ScoreTable("git open")
+
+            -- Find "go" and "og" in results
+            local go_score, og_score
+            for _, result in ipairs(results) do
+                if result.combo == "go" then
+                    go_score = result.score
+                end
+                if result.combo == "og" then
+                    og_score = result.score
+                end
+            end
+
+            -- Both "go" and "og" should exist and have high scores
+            assert.is_not_nil(go_score, "go should be in results")
+            assert.is_not_nil(og_score, "og should be in results")
+            assert.is_true(go_score > 0, "go should have a positive score")
+            assert.is_true(og_score > 0, "og should have a positive score")
+        end
+    )
+
+    it(
+        "should score word initial combinations highly for multi-word commands",
+        function()
+            local results = score.ScoreTable("find file in project")
+
+            -- Find "ff", "fi", "fp", "if", "ii", "ip", "pf", "pi", "pp" in results
+            local found_initials = {}
+            for _, result in ipairs(results) do
+                if
+                    result.combo == "ff"
+                    or result.combo == "fi"
+                    or result.combo == "fp"
+                    or result.combo == "if"
+                    or result.combo == "ip"
+                    or result.combo == "pf"
+                then
+                    found_initials[result.combo] = result.score
+                end
+            end
+
+            -- At least some of these should have high scores
+            assert.is_true(
+                (found_initials["ff"] and found_initials["ff"] > 0)
+                    or (found_initials["fi"] and found_initials["fi"] > 0)
+                    or (found_initials["fp"] and found_initials["fp"] > 0),
+                "at least one initial combination should have a positive score"
+            )
+        end
+    )
+
+    it("should include all permutations of word initials", function()
+        local results = score.ScoreTable("next buffer")
+
+        local nb_score, bn_score
+        for _, result in ipairs(results) do
+            if result.combo == "nb" then
+                nb_score = result.score
+            end
+            if result.combo == "bn" then
+                bn_score = result.score
+            end
+        end
+
+        -- Both directions should exist
+        assert.is_not_nil(nb_score, "nb should be in results")
+        assert.is_not_nil(bn_score, "bn should be in results")
+    end)
+end)


### PR DESCRIPTION
Improve mnemonic scoring by prioritizing combinations of word initials (e.g., "go" and "og" for "git open"). Update combo generation to include all permutations of word initials for multi-word commands. Add tests to verify scoring and combo generation for various cases.